### PR TITLE
add unsafe loading of yaml files

### DIFF
--- a/lib/ci/overrides.rb
+++ b/lib/ci/overrides.rb
@@ -125,7 +125,7 @@ module CI
     def global_override_load
       hash = {}
       @default_paths.each do |path|
-        hash.deep_merge!(YAML.load(File.read(path)))
+        hash.deep_merge!(YAML.unsafe_load(File.read(path)))
       end
       hash = CI::FNMatchPattern.convert_hash(hash, recurse: false)
       hash.each do |k, v|


### PR DESCRIPTION
Pysch 3.* used unsafe load by default, Pysch 4.* and above does not and errors